### PR TITLE
Support enum string value

### DIFF
--- a/Sources/ProtobufCodable/Encoding/EnumEncoder.swift
+++ b/Sources/ProtobufCodable/Encoding/EnumEncoder.swift
@@ -26,8 +26,12 @@ final class EnumEncoder: AbstractEncodingNode, SingleValueEncodingContainer {
         self.encodedValue = value
     }
 
+    func encode(_ value: String) throws {
+        self.encodedValue = value
+    }
+    
     func encode<T>(_ value: T) throws where T : Encodable {
-        throw EncodingError.unsupported(value, "Enum must use `RawValue` of `Int`, `Int64` or `Int32`, not \(T.self)", codingPath: codingPath)
+        throw EncodingError.unsupported(value, "Enum must use `RawValue` of `String`, `Int`, `Int64` or `Int32`, not \(T.self)", codingPath: codingPath)
     }
 }
 


### PR DESCRIPTION
add `func encode(_:) throws` to support enum string value

> Error
> invalidValue("Hello", Swift.EncodingError.Context(codingPath: [_DictionaryCodingKey(stringValue: "2", intValue: 2)], debugDescription: "Enum must use `RawValue` of `Int`, `Int64` or `Int32`, not String", underlyingError: nil))

```swift
enum Value: Codable {
  case int(Int)
  case string(String)
	
  init(from decoder: any Decoder) throws {
    let container = try decoder.singleValueContainer()
    if let value = try? container.decode(Int.self) {
      self = .int(value)
    } else if let value = try? container.decode(String.self) {
      self = .string(value)
    } else {
      throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid value")
    }
  }
	
  func encode(to encoder: any Encoder) throws {
    var container = encoder.singleValueContainer()
     switch self {
     case .int(let value):
       try container.encode(value)
     case .string(let value):
       try container.encode(value)
    }
  }
}

let dict: [Int: Value] = [
  1: .int(123),
  2: .string("Hello")
]

_ = try ProtobufEncoder.encode(dict)
```